### PR TITLE
fixed TypeError thrown by np.random.rand

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -5,7 +5,7 @@ import mrpt
 
 # Generate synthetic test data
 k = 10; n_queries = 100
-data = np.dot(np.random.rand(1e5,5), np.random.rand(5,100)).astype('float32')
+data = np.dot(np.random.rand(int(1e5),5), np.random.rand(5,100)).astype('float32')
 queries = np.dot(np.random.rand(n_queries,5), np.random.rand(5,100)).astype('float32')
 
 # Solve exact nearest neighbors with standard methods from scipy and numpy for reference


### PR DESCRIPTION
fixes a bug in demo.py that exists in python2 and python3 for numpy 1.12:

```
$ python3 -c 'import numpy; numpy.random.rand(1e5,5)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "mtrand.pyx", line 1347, in mtrand.RandomState.rand (numpy/random/mtrand/mtrand.c:19701)
  File "mtrand.pyx", line 856, in mtrand.RandomState.random_sample (numpy/random/mtrand/mtrand.c:15527)
  File "mtrand.pyx", line 167, in mtrand.cont0_array (numpy/random/mtrand/mtrand.c:6127)
TypeError: 'float' object cannot be interpreted as an integer
$ python -c 'import numpy; numpy.random.rand(1e5,5)'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "mtrand.pyx", line 1347, in mtrand.RandomState.rand (numpy/random/mtrand/mtrand.c:19701)
  File "mtrand.pyx", line 856, in mtrand.RandomState.random_sample (numpy/random/mtrand/mtrand.c:15527)
  File "mtrand.pyx", line 167, in mtrand.cont0_array (numpy/random/mtrand/mtrand.c:6127)
TypeError: 'float' object cannot be interpreted as an index
```