### PR TITLE
Solve ppc64le build due to unexisting -march

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,12 @@ import setuptools
 import numpy
 from setuptools import Extension
 
+# Not all CPUs have march as a tuning parameter
+import platform
+cputune = ['-march=native',]
+if platform.machine() == "ppc64le":
+    cputune = ['-mcpu=native',]
+
 setuptools.setup(
     name='mrpt',
     version='0.1',
@@ -18,8 +24,8 @@ setuptools.setup(
             sources = [
                 'cpp/mrptmodule.cpp',
             ],
-            extra_compile_args=['-std=c++11', '-O3', '-march=native', '-ffast-math', '-s',
-                                '-fno-rtti', '-fopenmp', '-DNDEBUG'],
+            extra_compile_args=['-std=c++11', '-O3', '-ffast-math', '-s',
+                                '-fno-rtti', '-fopenmp', '-DNDEBUG'] + cputune,
             extra_link_args=['-lgomp'],
             libraries = ['stdc++'],
             include_dirs = ['cpp/lib', numpy.get_include()]


### PR DESCRIPTION
On ppc64le (e.g: POWER8 machines), the -mcpu should be used instead.

References:
https://gcc.gnu.org/onlinedocs/gcc-4.5.3/gcc/i386-and-x86_002d64-Options.html
https://gcc.gnu.org/onlinedocs/gcc/RS_002f6000-and-PowerPC-Options.html